### PR TITLE
use tile-reduce raw to speed up

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function indexer(mbtiles, output, options) {
     Object.assign(options, {
         zoom: 12,
         map: path.join(__dirname, 'lib', 'reducer.js'),
-        sources: [{name: 'qatiles', mbtiles}],
+        sources: [{name: 'qatiles', mbtiles, raw: true}],
         mapOptions: {
             output: output,
             debug: debug,

--- a/lib/qa-tiles-filter.js
+++ b/lib/qa-tiles-filter.js
@@ -6,20 +6,22 @@
  * @example
  * const lines = filterQATiles(features);
  */
-module.exports = function (features) {
+module.exports = function (tile, features) {
     const results = [];
-    features.forEach(feature => {
-        // Only include (Multi)LineString
-        if (feature.geometry.type !== 'LineString' && feature.geometry.type !== 'MultiLineString') return;
+    for (var i = 0; i < features.length; i++) {
+        var feature = features.feature(i);
+
+        // Only include lines
+        if (feature.type !== 2) continue;
 
         // Only include highway OSM data
-        if (!feature.properties.highway) return;
+        if (!feature.properties.highway) continue;
 
         // Feature must have name or ref
-        if (!feature.properties.name && !feature.properties.ref) return;
+        if (!feature.properties.name && !feature.properties.ref) continue;
 
-        // Only include certain OSM properties
-        feature.properties = {
+        var geojson = feature.toGeoJSON(tile[0], tile[1], tile[2]);
+        geojson.properties = {
             name: feature.properties.name,
             'name:en': feature.properties['name:en'],
             'name:fr': feature.properties['name:fr'],
@@ -29,7 +31,9 @@ module.exports = function (features) {
             ref: feature.properties.ref,
             '@id': feature.properties['@id']
         };
-        results.push(feature);
-    });
+
+        results.push(geojson);
+    }
+
     return results;
 };

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -17,8 +17,8 @@ const output = global.mapOptions && global.mapOptions.output;
 module.exports = (sources, tile, writeData, done) => {
     // Main processing
     const quadkey = tilebelt.tileToQuadkey(tile);
-    const features = sources.qatiles.osm.features;
-    const highways = qaTilesFilter(features);
+    const features = sources.qatiles.osm;
+    const highways = qaTilesFilter(tile, features);
     const intersects = intersections(highways);
     const index = createIndex(intersects);
 


### PR DESCRIPTION
Using tile-reduce `raw` mode lets us filter before geometries are decoded, which means 🏎 💨 