### PR TITLE
[not ready] extract index DB

### DIFF
--- a/bin/cross-street-indexer.js
+++ b/bin/cross-street-indexer.js
@@ -11,6 +11,7 @@ const cli = meow(`
     --bbox      Excludes QATiles by BBox
     --tiles     Excludes QATiles by an Array of Tiles
     --debug     [false] Enables DEBUG mode
+    --dbindex   Create index db of the named type. Currently supported: leveldb
   Examples:
     $ cross-street-indexer latest.planet.mbtiles
     $ cross-street-indexer latest.planet.mbtiles --tiles [[654,1584,12]]

--- a/indexes/leveldb.js
+++ b/indexes/leveldb.js
@@ -1,0 +1,61 @@
+const levelup = require('level');
+const queue = require('d3-queue').queue;
+const path = require('path');
+const tilebelt = require('tilebelt');
+const fs = require('fs');
+const split = require('binary-split');
+
+// TODO: ditch the global (no quadkey) index?
+function LevelIndex(options, output) {
+    this.options = options;
+    this.output = output;
+    this.db = levelup(path.join(output, 'leveldb'));
+    this.queue = queue(1);
+}
+
+LevelIndex.prototype.addTileToIndex = function(tile, callback) {
+    const self = this;
+    const quadkey = tilebelt.tileToQuadkey(tile);
+    const quadFile = path.resolve(this.output, quadkey + '.json');
+    const ops = [];
+
+    fs.createReadStream(quadFile)
+        .pipe(split())
+        .on('data', function (line) {
+            const json = JSON.parse(line.toString());
+            const hash = Object.keys(json)[0];
+            const coord = json[hash].join(',')
+            const hashQuadkey = [quadkey, hash].join('+')
+            ops.push({type: 'put', key: hash, value: coord});
+            ops.push({type: 'put', key: hashQuadkey, value: coord});
+        })
+        .on('finish', function () {
+          self.db.batch(ops, error => {
+              if (error) throw new Error(error);
+              callback(null);
+          });
+        });
+}
+
+
+LevelIndex.prototype.query = function(norm1, norm2, quadkey) {
+    const db = this.db;
+    return new Promise(resolve => {
+        // If there's a quadkey, search the specific quad
+        // Otherwise, search the global index (which is unlikely to be correct)
+        const search = quadkey ?
+            [quadkey, norm1, norm2].join('+') :
+            [norm1, norm2].join('+');
+
+        db.get(search, (error, value) => {
+            if (error) return resolve(undefined);
+            if (value) return resolve(value.split(',').map(Number));
+        });
+    });
+};
+
+LevelIndex.prototype.close = function () {
+    this.db.close();
+};
+
+module.exports = LevelIndex;

--- a/lib/reducer.js
+++ b/lib/reducer.js
@@ -61,5 +61,6 @@ module.exports = (sources, tile, writeData, done) => {
     }
     // Output Results
     if (index.size) fs.writeFileSync(path.join(output, quadkey + '.json'), map2jsonl(index));
-    done(null, map2json(index));
+
+    done(null, index.size);
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@turf/helpers": "^4.3.0",
     "@turf/line-intersect": "^4.4.0",
     "@turf/meta": "^4.3.0",
+    "binary-split": "^1.0.3",
     "d3-queue": "^3.0.7",
     "global-mercator": "2.7.0",
     "level": "^1.7.0",


### PR DESCRIPTION
- Extracts LevelDB to be an optional **index DB**. You'd want to use this for query speed, or portability – if you don't mind downloading the entire index at once, a tar.gz'd levelDB is simpler than downloading lots of files
  - Optional Creation –  If no index DB is specified, only index json files are written
  - Optional Querying – The index DB can be used (explicit) or ignored (default)
- Adding a different index DB type (like redis? or ???) requires only adding a new class in the `indexes` folder that matches the index DB api
- Adds the ability to query index json files with `cross-street-search`, without streaming them in


TODO:
- [ ] Tests are very broken
- [ ] Document index DB options
- [ ] Document index DB API (and example of adding another class?)
- [ ] Revisit naming for the `--dbindex` option
